### PR TITLE
fix(ci): bump dorny/paths-filter v3 → v4.0.1 for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       # to validate the release artifact.
       - name: Detect code-affecting paths
         id: filter
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             code:


### PR DESCRIPTION
## Summary

Resolves the Node 20 deprecation warning surfaced by PR #71's CI run:

> ##[warning]Node.js 20 actions are deprecated. The following actions
> are running on Node.js 20 ... `dorny/paths-filter@d1c1ffe...`

`v4.0.1` (published 2026-03-17) ships with `using: 'node24'`. Functionally backward-compatible with the v3 filter expression — same `code:` and `image:` outputs, same `paths-filter` semantics — just the runtime moves from Node 20 (deprecated, removed Sep 2026) to Node 24.

## Test plan

- [ ] CI green on this branch
- [ ] Verify Node 20 deprecation warning no longer appears in the run logs